### PR TITLE
migration to androidx

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
     }
 }
 
-repositories {https://flutter.io/docs/development/packages-and-plugins/androidx-compatibility
+repositories {
     maven {
         url './libs'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,9 +3,9 @@ version '1.0-SNAPSHOT'
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION                 = 27
+def DEFAULT_COMPILE_SDK_VERSION                 = 28
 def DEFAULT_PLAY_SERVICES_LOCATION_VERSION      = "16.0.0"
-def DEFAULT_SUPPORT_LIB_VERSION                 = "27.1.1"
+def DEFAULT_SUPPORT_LIB_VERSION                 = "1.0.2"
 def DEFAULT_OK_HTTP_VERSION                     = "3.12.1"
 def DEFAULT_ANDROID_PERMISSIONS_VERSION         = "0.1.7"
 
@@ -18,14 +18,14 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'
     }
 }
 
-repositories {
+repositories {https://flutter.io/docs/development/packages-and-plugins/androidx-compatibility
     maven {
         url './libs'
     }
@@ -45,7 +45,5 @@ dependencies {
     implementation 'com.github.tony19:logback-android:1.3.0-2'
     // android-permissions
     implementation "com.intentfilter:android-permissions:$androidPermissionsVersion"
-    implementation "com.android.support:appcompat-v7:$supportLibVersion"
-
-
+    implementation 'androidx.appcompat:appcompat:$supportLibVersion'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableJetifier=true
+android.useAndroidX=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/docs/INSTALL-ANDROID.md
+++ b/docs/INSTALL-ANDROID.md
@@ -42,9 +42,9 @@ As an app grows in complexity and imports a variety of 3rd-party modules, it hel
 ```diff
 buildscript {
 +   ext {
-+       compileSdkVersion   = 27
-+       targetSdkVersion    = 27
-+       supportLibVersion   = "27.1.1"
++       compileSdkVersion   = 28
++       targetSdkVersion    = 28
++       supportLibVersion   = "1.0.2"
 +       playServicesLocationVersion = "16.0.0"
 +   }
 
@@ -54,7 +54,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
     }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     signingConfigs {
         release {
@@ -64,9 +64,7 @@ dependencies {
     def supportLibVersion = rootProject.ext.supportLibVersion
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-
-    implementation "com.android.support:appcompat-v7:$supportLibVersion"
-    
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    implementation 'androidx.appcompat:appcompat:$supportLibVersion'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         compileSdkVersion   = 28
-        targetSdkVersion    = 27
+        targetSdkVersion    = 28
         supportLibVersion   = "28.0.0"
         playServicesLocationVersion = "16.0.0"
     }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableJetifier=true
+android.useAndroidX=true


### PR DESCRIPTION
latest stable flutter 1.2.1 has a breaking change and forces applications to migrate from android.support to androidx packages. this pull request should do the trick. (not sure about necessity of upgrading your aar library too, but hopefully not)

more info here:

1. https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility
2. https://medium.com/@gabrc52/how-to-migrate-your-flutter-app-to-androidx-1202ad43c8c8