### PR TITLE
correct geofence* tags

### DIFF
--- a/lib/models/http_event.dart
+++ b/lib/models/http_event.dart
@@ -164,8 +164,8 @@ part of flt_background_geolocation;
 ///
 /// | Tag | Type | Description |
 /// |-----|------|-------------|
-/// | `geofence_identifier` | `String` | Which geofence?|
-/// | `geofence_action` | `String` | `ENTER,EXIT,DWELL`|
+/// | `geofence.identifier` | `String` | Which geofence?|
+/// | `geofence.action` | `String` | `ENTER,EXIT,DWELL`|
 ///
 /// #### Quoting String Values
 ///


### PR DESCRIPTION
This threw me off for second. The docs on [this page](https://pub.dartlang.org/documentation/flutter_background_geolocation/latest/flt_background_geolocation/HttpEvent-class.html) have the incorrect tags. They are however correct on [this page](https://pub.dartlang.org/documentation/flutter_background_geolocation/latest/flt_background_geolocation/Config/geofenceTemplate.html).