### PR TITLE
appending .git to latest from git example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ dependencies:
 dependencies:
   flutter_background_geolocation:
     git:
-      url: https://github.com/transistorsoft/flutter_background_geolocation
+      url: https://github.com/transistorsoft/flutter_background_geolocation.git
 ```
 
 ## :large_blue_diamond: Setup Guides


### PR DESCRIPTION
`$ flutter packages get` fails with `Could not find a file named "pubspec.yaml" in https://github.com/transistorsoft/flutter_background_geolocation` if the git url is missing the postfix `.git` as per the [dartlang docs](https://www.dartlang.org/tools/pub/dependencies#git-packages).