### PR TITLE
Add android clean instructions for 1.9.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ allprojects {
 }
 ```
 
+You might then clean your android project: 
+
+```sh
+cd android
+./gradlew clean
+```
+
 - [Fixed][Android] `onConnectivityChange` can report incorrect value for `enabled` when toggling between Wifi Off / Airplane mode.
 
 ## 1.8.0 - 2020-05-28


### PR DESCRIPTION
I encoutered the #308 error and fixed it with @christocracy [fix](https://github.com/transistorsoft/flutter_background_geolocation/issues/308#issuecomment-647640099).  

It should be in Changelog to allow faster upgrade.

Thanks! 
