### PR TITLE
Update package version in README.md's pubspec.yaml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The **[Android module](https://www.transistorsoft.com/shop/products/flutter-back
 
 ```yaml
 dependencies:
-  flutter_background_geolocation: '^4.8.1'
+  flutter_background_geolocation: '^4.11.1'
 ```
 
 ### Or latest from Git:


### PR DESCRIPTION
I noticed that the latest package version is `4.11.1`. But the `pubspec.yaml` example on the README uses `^4.8.1`.

So this PR just updates that example from using `^4.8.1` to `^4.11.1` 