### PR TITLE
Add multi FlutterEngine support to Android

### DIFF
--- a/android/src/main/java/com/transistorsoft/flutter/backgroundgeolocation/FLTBackgroundGeolocationPlugin.java
+++ b/android/src/main/java/com/transistorsoft/flutter/backgroundgeolocation/FLTBackgroundGeolocationPlugin.java
@@ -20,7 +20,7 @@ public class FLTBackgroundGeolocationPlugin implements FlutterPlugin, ActivityAw
 
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPlugin.FlutterPluginBinding binding) {
-        BackgroundGeolocationModule.getInstance().onDetachedFromEngine();
+        BackgroundGeolocationModule.getInstance().onDetachedFromEngine(binding.getBinaryMessenger());
     }
 
     @Override


### PR DESCRIPTION
This pull request should fix the issue as described in #1191.

Since the problem doesn't happen for iOS, due to it already supporting multiple engines, this PR only targets Android.