### PR TITLE
Update INSTALL-ANDROID.md

### DIFF
--- a/help/INSTALL-ANDROID.md
+++ b/help/INSTALL-ANDROID.md
@@ -50,13 +50,18 @@ allprojects {  // <-- IMPORTANT:  allprojects
 - #### If you're using `flutter >= 3.19.0` ([New Android Architecture](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply)):
 
 ```diff
-+ext {
-+    compileSdkVersion   = 33                // or higher / as desired
-+    targetSdkVersion    = 33                // or higher / as desired
-+    minSdkVersion       = 21                // Required minimum
-+    appCompatVersion    = "1.4.2"           // or higher / as desired
-+    playServicesLocationVersion = "21.0.1"  // or higher / as desired
+allprojects {
+.
+.
+.
++   ext {
++       compileSdkVersion   = 33                // or higher / as desired
++       targetSdkVersion    = 33                // or higher / as desired
++       minSdkVersion       = 21                // Required minimum
++       appCompatVersion    = "1.4.2"           // or higher / as desired
++       playServicesLocationVersion = "21.0.1"  // or higher / as desired
 +}
+}
 ```
 
 - #### Otherwise for `flutter < 3.19.0` (Old Android Architecture):


### PR DESCRIPTION
I have been struggling to make Android work because installation was not very clear...

As [it is written at the moment](https://github.com/transistorsoft/flutter_background_geolocation/blob/master/help/INSTALL-ANDROID.md#if-youre-using-flutter--3190-new-android-architecture), I did put the `ext{}` object at the root of the file.

I would get this error which can be hard to understand
```
> Cannot get property 'compileSdkVersion' on extra properties extension as it does not exist
```

This change should make this clearer, by referencing `allprojects{}`
